### PR TITLE
feat: rust editor grouping improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "semantic-edit-mcp"
 version = "0.1.2"
 authors = ["Jacob Rothstein <hi@jbr.me>", "Anthropic Claude Sonnet 4"]
-edition = "2021"
+edition = "2024"
 description = "MCP server for semantic code editing with tree-sitter"
 readme = "README.md"
 repository = "https://github.com/jbr/semantic-edit-mcp"

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -8,7 +8,7 @@ use crate::{
     state::StagedOperation,
     validation::ContextValidator,
 };
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use diffy::{DiffOptions, Patch, PatchFormatter};
 use ropey::Rope;
 use std::{collections::BTreeSet, iter, path::PathBuf};

--- a/src/editor/edit.rs
+++ b/src/editor/edit.rs
@@ -25,7 +25,7 @@ pub struct Edit<'editor, 'language> {
     #[field(get, take)]
     output: Option<String>,
     #[field(get, set, with, take)]
-    node: Option<Node<'editor>>,
+    nodes: Option<Vec<Node<'editor>>>,
     #[field(with, get, set)]
     annotation: Option<&'static str>,
 }
@@ -35,7 +35,7 @@ impl PartialEq for Edit<'_, '_> {
         std::ptr::eq(self.editor, other.editor)
             && self.content == other.content
             && self.position == other.position
-            && self.node == other.node
+            && self.nodes == other.nodes
     }
 }
 
@@ -52,8 +52,15 @@ impl<'editor, 'language> Debug for Edit<'editor, 'language> {
         if let Some(valid) = self.valid {
             s.field("valid", &valid);
         }
-        if let Some(node) = self.node {
-            s.field("node_kind", &format_args!("{}", node.kind()));
+        if let Some(nodes) = &self.nodes {
+            s.field(
+                "node_kinds",
+                &nodes
+                    .iter()
+                    .map(|node| node.kind().to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
         }
 
         if let Some(edit_region) = self.edit_region() {
@@ -104,7 +111,7 @@ impl<'editor, 'language> Edit<'editor, 'language> {
             valid: None,
             message: None,
             output: None,
-            node: None,
+            nodes: None,
             annotation: None,
         }
     }

--- a/src/editor/edit_iterator.rs
+++ b/src/editor/edit_iterator.rs
@@ -140,7 +140,7 @@ impl<'editor, 'language> EditIterator<'editor, 'language> {
                     candidates.push(
                         self.build_edit(nodes.first().as_ref().unwrap().start_byte())
                             .with_end_byte(nodes.last().as_ref().unwrap().end_byte())
-                            .with_node(*nodes.first().unwrap())
+                            .with_nodes(nodes)
                             .with_annotation("node range"),
                     );
                 }
@@ -148,7 +148,7 @@ impl<'editor, 'language> EditIterator<'editor, 'language> {
                 candidates.push(
                     self.build_edit(parent.start_byte())
                         .with_end_byte(parent.end_byte())
-                        .with_node(parent)
+                        .with_nodes(vec![parent])
                         .with_annotation("common parent"),
                 );
             }

--- a/src/languages/ecma_editor.rs
+++ b/src/languages/ecma_editor.rs
@@ -1,5 +1,5 @@
 use crate::{indentation::Indentation, languages::LanguageEditor};
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use std::{
     io::{Read, Write},
     path::Path,

--- a/src/languages/javascript.rs
+++ b/src/languages/javascript.rs
@@ -1,4 +1,4 @@
-use super::{ecma_editor::EcmaEditor, LanguageCommon, LanguageName};
+use super::{LanguageCommon, LanguageName, ecma_editor::EcmaEditor};
 
 pub fn language() -> LanguageCommon {
     LanguageCommon {

--- a/src/languages/json.rs
+++ b/src/languages/json.rs
@@ -1,6 +1,6 @@
 use crate::{
     editor::{Edit, EditIterator, Editor},
-    languages::{ecma_editor::EcmaEditor, LanguageCommon, LanguageEditor, LanguageName},
+    languages::{LanguageCommon, LanguageEditor, LanguageName, ecma_editor::EcmaEditor},
 };
 use anyhow::Result;
 use std::path::Path;

--- a/src/languages/jsx.rs
+++ b/src/languages/jsx.rs
@@ -1,4 +1,4 @@
-use crate::languages::{ecma_editor::EcmaEditor, LanguageCommon, LanguageName};
+use crate::languages::{LanguageCommon, LanguageName, ecma_editor::EcmaEditor};
 
 pub fn language() -> LanguageCommon {
     LanguageCommon {

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -12,7 +12,7 @@ pub mod typescript;
 
 use anyhow::Result;
 use clap::ValueEnum;
-use enum_map::{enum_map, Enum, EnumMap};
+use enum_map::{Enum, EnumMap, enum_map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{

--- a/src/languages/plain.rs
+++ b/src/languages/plain.rs
@@ -31,7 +31,7 @@ impl LanguageEditor for PlainEditor {
         editor: &'editor Editor<'language>,
     ) -> Result<Vec<Edit<'editor, 'language>>, String> {
         let mut edits = EditIterator::new(editor).find_edits()?;
-        edits.retain(|x| x.node().is_none());
+        edits.retain(|x| x.nodes().is_none());
 
         Ok(edits)
     }

--- a/src/languages/plain.rs
+++ b/src/languages/plain.rs
@@ -1,6 +1,6 @@
 use crate::{
     editor::{Edit, EditIterator, Editor},
-    languages::{traits::LanguageEditor, LanguageCommon, LanguageName},
+    languages::{LanguageCommon, LanguageName, traits::LanguageEditor},
 };
 use anyhow::Result;
 

--- a/src/languages/rust.rs
+++ b/src/languages/rust.rs
@@ -1,14 +1,13 @@
 use crate::editor::{Edit, EditIterator, Editor};
 
-use super::{traits::LanguageEditor, LanguageCommon, LanguageName};
-use anyhow::{anyhow, Result};
+use super::{LanguageCommon, LanguageName, traits::LanguageEditor};
+use anyhow::{Result, anyhow};
 use std::{
-    collections::VecDeque,
     io::{Read, Write},
     path::Path,
     process::{Command, Stdio},
 };
-use tree_sitter::{Node, Query, Tree};
+use tree_sitter::{Node, Query};
 
 pub fn language() -> LanguageCommon {
     let language = tree_sitter_rust::LANGUAGE.into();
@@ -66,9 +65,23 @@ impl LanguageEditor for RustEditor {
         let mut edits = edit_iterator.find_edits()?;
         let mut parser = editor.language().tree_sitter_parser().unwrap();
         let content_parse = parser.parse(editor.content(), None);
+
         if let Some(content_parse) = content_parse {
             for edit in &mut edits {
-                handle_grouping(edit, &content_parse);
+                let root = content_parse.root_node();
+                let mut walk = root.walk();
+                let replacement = root.children(&mut walk).collect::<Vec<_>>();
+
+                if let Some("line_comment") = replacement.last().map(|node| node.kind())
+                    && let Some("line_comment") = edit
+                        .nodes()
+                        .and_then(|nodes| nodes.last().map(|node| node.kind()))
+                    && !editor.content().ends_with('\n')
+                {
+                    edit.content_mut().to_mut().push('\n');
+                } else {
+                    handle_grouping(edit, &replacement);
+                }
             }
         }
 
@@ -76,63 +89,153 @@ impl LanguageEditor for RustEditor {
     }
 }
 
-fn handle_grouping<'language, 'editor>(
-    edit: &mut Edit<'language, 'editor>,
-    content_parse: &Tree,
+fn handle_grouping<'editor, 'language>(
+    edit: &mut Edit<'editor, 'language>,
+    replacement: &[Node<'_>],
 ) -> Option<()> {
-    let root = content_parse.root_node();
-    let mut walk = root.walk();
-    let mut replacement = root.children(&mut walk);
+    let replacement_has_preceding = replacement.iter().any(|node| is_preceding_item(*node));
+    let replacement_has_primary = replacement.iter().any(|node| !is_preceding_item(*node));
 
-    let edit_node = edit.node()?;
-    let replacement_node =
-        replacement.find(|replacement_node| replacement_node.kind() == edit_node.kind())?;
+    // Keep expanding until no more expansions are needed
+    while let Some(expansion_type) = determine_expansion_type(
+        edit.nodes()?,
+        replacement_has_preceding,
+        replacement_has_primary,
+    ) {
+        let expanded_nodes: Vec<Node<'editor>> = match expansion_type {
+            ExpansionType::BackwardsToMatchPattern => {
+                let replacement_pattern = get_preceding_pattern(replacement);
+                expand_backwards_to_match_pattern(edit.nodes()?, &replacement_pattern)?
+            }
+            ExpansionType::ForwardToIncludePrimary => {
+                expand_forward_to_include_primary(edit.nodes()?)?
+            }
+        };
 
-    // return if the replacement content has no grouped nodes
-    find_grouped_nodes(replacement_node)?;
-
-    let source_preceeding = find_grouped_nodes(*edit_node)?;
-    let position = edit.position_mut();
-    position.set_start_byte(source_preceeding.first()?.start_byte());
-    if position.end_byte.is_some() {
-        position.end_byte = Some(source_preceeding.last()?.end_byte());
+        apply_expansion(edit, expanded_nodes, expansion_type);
     }
 
-    edit.set_annotation("rust: grouped").take_node();
-    None
+    Some(())
 }
 
-fn is_preceeding_item(node: Node<'_>) -> bool {
-    matches!(node.kind(), "line_comment" | "attribute_item")
+#[derive(Debug)]
+enum ExpansionType {
+    BackwardsToMatchPattern,
+    ForwardToIncludePrimary,
 }
 
-fn find_grouped_nodes<'a>(start_node: Node<'a>) -> Option<Vec<Node<'a>>> {
-    let mut group: VecDeque<Node<'a>> = VecDeque::new();
-    group.push_front(start_node);
+fn determine_expansion_type<'editor>(
+    edit_nodes: &[Node<'editor>],
+    replacement_has_preceding: bool,
+    replacement_has_primary: bool,
+) -> Option<ExpansionType> {
+    let selection_has_preceding = edit_nodes.iter().any(|node| is_preceding_item(*node));
+    let selection_has_primary = edit_nodes.iter().any(|node| !is_preceding_item(*node));
+    let selection_only_preceding = selection_has_preceding && !selection_has_primary;
 
-    let mut node = start_node;
+    if replacement_has_preceding && replacement_has_primary && !selection_has_preceding {
+        // Risk of duplication: expand backwards to include matching preceding items
+        Some(ExpansionType::BackwardsToMatchPattern)
+    } else if selection_only_preceding && replacement_has_primary {
+        // Selected only comments/attributes but replacing with full logical unit
+        Some(ExpansionType::ForwardToIncludePrimary)
+    } else {
+        // No expansion needed
+        None
+    }
+}
 
-    while let Some(prev) = node.prev_sibling() {
-        if is_preceeding_item(prev) {
-            node = prev;
-            group.push_front(prev);
-        } else {
-            break;
-        }
+fn get_preceding_pattern<'a>(replacement: &[Node<'a>]) -> Vec<&'a str> {
+    replacement
+        .iter()
+        .take_while(|node| is_preceding_item(**node))
+        .map(|node| node.kind())
+        .collect()
+}
+
+fn expand_backwards_to_match_pattern<'a>(
+    edit_nodes: &[Node<'a>],
+    replacement_pattern: &[&str],
+) -> Option<Vec<Node<'a>>> {
+    if replacement_pattern.is_empty() {
+        return None;
     }
 
-    let mut node = start_node;
+    // Find first primary node in selection
+    let first_primary = edit_nodes.iter().find(|node| !is_preceding_item(**node))?;
 
-    if is_preceeding_item(start_node) {
-        while let Some(next) = node.next_sibling() {
-            group.push_back(next);
-            if is_preceeding_item(next) {
-                node = next;
-            } else {
-                break;
+    // Walk backwards from first primary node to collect matching preceding items
+    let mut preceding_items = Vec::new();
+    let mut current = *first_primary;
+    let mut pattern_index = replacement_pattern.len();
+
+    // Walk backwards, matching the replacement pattern in reverse
+    while let Some(prev) = current.prev_sibling() {
+        if pattern_index > 0 && is_preceding_item(prev) {
+            let expected_kind = replacement_pattern[pattern_index - 1];
+            if prev.kind() == expected_kind {
+                preceding_items.insert(0, prev);
+                pattern_index -= 1;
+                current = prev;
+                continue;
             }
         }
+        break;
     }
 
-    (group.len() > 1).then(|| group.into())
+    // Only return Some if we actually found preceding items to add
+    if preceding_items.is_empty() {
+        return None;
+    }
+
+    // Build the expanded selection
+    let mut expanded = preceding_items;
+    expanded.extend_from_slice(edit_nodes);
+    Some(expanded)
+}
+
+fn expand_forward_to_include_primary<'a>(edit_nodes: &[Node<'a>]) -> Option<Vec<Node<'a>>> {
+    let last_node = edit_nodes.last()?;
+    let mut expanded = edit_nodes.to_vec();
+    let mut current = *last_node;
+
+    // Walk forward until we find a primary item
+    while let Some(next) = current.next_sibling() {
+        expanded.push(next);
+        if !is_preceding_item(next) {
+            break; // Found the primary item
+        }
+        current = next;
+    }
+
+    Some(expanded)
+}
+
+fn apply_expansion<'editor, 'language>(
+    edit: &mut Edit<'editor, 'language>,
+    expanded_nodes: Vec<Node<'editor>>,
+    expansion_type: ExpansionType,
+) {
+    let position = edit.position_mut();
+
+    if let (Some(first), Some(last)) = (expanded_nodes.first(), expanded_nodes.last()) {
+        position.set_start_byte(first.start_byte());
+        if position.end_byte.is_some() {
+            position.end_byte = Some(last.end_byte());
+        }
+    }
+
+    let annotation = match expansion_type {
+        ExpansionType::BackwardsToMatchPattern => "rust: expanded backwards to match pattern",
+        ExpansionType::ForwardToIncludePrimary => "rust: expanded forward to include primary",
+    };
+
+    edit.set_annotation(annotation).set_nodes(expanded_nodes);
+}
+
+fn is_preceding_item(node: Node<'_>) -> bool {
+    matches!(
+        node.kind(),
+        "line_comment" | "block_comment" | "attribute_item"
+    )
 }

--- a/src/languages/toml.rs
+++ b/src/languages/toml.rs
@@ -1,4 +1,4 @@
-use crate::languages::{traits::LanguageEditor, LanguageCommon, LanguageName};
+use crate::languages::{LanguageCommon, LanguageName, traits::LanguageEditor};
 use anyhow::Result;
 use std::{ops::Range, path::Path};
 use taplo::rowan::{TextRange, TextSize};

--- a/src/languages/tsx.rs
+++ b/src/languages/tsx.rs
@@ -1,4 +1,4 @@
-use crate::languages::{ecma_editor::EcmaEditor, LanguageCommon, LanguageName};
+use crate::languages::{LanguageCommon, LanguageName, ecma_editor::EcmaEditor};
 
 pub fn language() -> LanguageCommon {
     LanguageCommon {

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,7 +3,7 @@ use crate::{
     languages::{LanguageName, LanguageRegistry},
     selector::Selector,
 };
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use fieldwork::Fieldwork;
 use mcplease::session::SessionStore;
 use serde::{Deserialize, Serialize};

--- a/src/tests/semantic_validation.rs
+++ b/src/tests/semantic_validation.rs
@@ -34,11 +34,13 @@ mod python {
 
     #[test]
     fn no_self_outside_class() {
-        assert!(validate_code(
-            r#"def method_with_self(self):\n    return "this has self but is outside class"#,
-            LanguageName::Python
-        )
-        .is_some());
+        assert!(
+            validate_code(
+                r#"def method_with_self(self):\n    return "this has self but is outside class"#,
+                LanguageName::Python
+            )
+            .is_some()
+        );
     }
 
     #[test]

--- a/tests/snapshots/rust/attributes-2/output.rs
+++ b/tests/snapshots/rust/attributes-2/output.rs
@@ -1,16 +1,16 @@
 use serde::{Deserialize, Serialize};
 
-/// Administrative user with elevated privileges
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct AdminUser {
-    pub user: User,
-    pub permissions: Vec<String>,
-}
 /// Represents a user in the system
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct User {
     pub id: u64,
     pub username: String,
+}
+/// Administrative user with elevated privileges
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdminUser {
+    pub user: User,
+    pub permissions: Vec<String>,
 }
 
 /// User profile information

--- a/tests/snapshots/rust/attributes-2/response.txt
+++ b/tests/snapshots/rust/attributes-2/response.txt
@@ -3,30 +3,32 @@ Previewing: insert after
 Note: the editor applies a consistent formatting style to the entire file, including your edit
 
 ===DIFF===
- use serde::{Deserialize, Serialize};
-
+     pub id: u64,
+     pub username: String,
+ }
 +/// Administrative user with elevated privileges
 +#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 +pub struct AdminUser {
 +    pub user: User,
 +    pub permissions: Vec<String>,
 +}
- /// Represents a user in the system
+
+ /// User profile information
  #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
- pub struct User {
 === snapshot test tool call: persist_edit ===
 insert after operation result:
 Applied insert after operation
 
 ===DIFF===
- use serde::{Deserialize, Serialize};
-
+     pub id: u64,
+     pub username: String,
+ }
 +/// Administrative user with elevated privileges
 +#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 +pub struct AdminUser {
 +    pub user: User,
 +    pub permissions: Vec<String>,
 +}
- /// Represents a user in the system
+
+ /// User profile information
  #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
- pub struct User {

--- a/tests/snapshots/rust/replacing_comment/args.json
+++ b/tests/snapshots/rust/replacing_comment/args.json
@@ -1,0 +1,5 @@
+[{"name": "preview_edit", "arguments":{
+  "operation": "replace",
+  "anchor": "/// this is a multiline comment\n/// line 2\n",
+  "content": "/// just one line and no trailing newline"
+}}]

--- a/tests/snapshots/rust/replacing_comment/input.rs
+++ b/tests/snapshots/rust/replacing_comment/input.rs
@@ -1,0 +1,7 @@
+/// this is a multiline comment
+/// line 2
+#[derive(Debug)]
+struct MyStruct {
+    field1: (),
+    field2: (),
+}

--- a/tests/snapshots/rust/replacing_comment/response.txt
+++ b/tests/snapshots/rust/replacing_comment/response.txt
@@ -1,0 +1,11 @@
+=== snapshot test tool call: preview_edit ===
+Previewing: replace
+Note: the editor applies a consistent formatting style to the entire file, including your edit
+
+===DIFF===
+-/// this is a multiline comment
+-/// line 2
++/// just one line and no trailing newline
+ #[derive(Debug)]
+ struct MyStruct {
+     field1: (),


### PR DESCRIPTION
additionally, handle comment replacements that don't end with newlines and make Edit::nodes an Option<Vec<Node>> instead of Option<Node>